### PR TITLE
Add in ability to customize 'next' button

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ For core model attributes see [**core model attributes**](https://github.com/ada
 
 **_component** (string): This value must be: `stacklist`.
 
-**_items** (array): An array of text strings, each one representing one list item. Text may include html.
+**_items** (array): Each item represents a sliding element.
+
+>**description** (string): The main text for sliding item.
+
+>**next** (string): This text becomes the 'next' button.
 
 ## Limitations
 

--- a/example.json
+++ b/example.json
@@ -7,11 +7,29 @@
     "displayTitle": "Stacklist",
     "body": "",
     "_items": [
-        "This component is useful for making boring text lists that little bit more interactive.",
-        "List items slide in from alternating sides.",
-        "There is no limit to the number of items you can have.",
-        "Although if you have too many it will be a bit boring.",
-        "At least now you get the gist of how this works.",
-        "That's pretty much it."
+        {
+            "description": "This component is useful for making boring text lists that little bit more interactive.",
+            "next": "Show me more!"
+        },
+        {
+            "description": "List items slide in from alternating sides.",
+            "next": "... and you can modify this text!"
+        },
+        {
+            "description": "There is no limit to the number of items you can have.",
+            "next": "It's localisation friendly"
+        },
+        {
+            "description": "Although if you have too many it will be a bit boring.",
+            "next": "... but you can customize it"
+        },     
+        {
+            "description": "At least now you get the gist of how this works.",
+            "next": "I get it!"
+        },  
+        {
+            "description": "That's pretty much it.",
+            "next": "Step 5"
+        }            
     ]
 }

--- a/example.json
+++ b/example.json
@@ -8,28 +8,28 @@
     "body": "",
     "_items": [
         {
-            "description": "This component is useful for making boring text lists that little bit more interactive.",
+            "body": "This component is useful for making boring text lists that little bit more interactive.",
             "next": "Show me more!"
         },
         {
-            "description": "List items slide in from alternating sides.",
+            "body": "List items slide in from alternating sides.",
             "next": "... and you can modify this text!"
         },
         {
-            "description": "There is no limit to the number of items you can have.",
+            "body": "There is no limit to the number of items you can have.",
             "next": "It's localisation friendly"
         },
         {
-            "description": "Although if you have too many it will be a bit boring.",
+            "body": "Although if you have too many it will be a bit boring.",
             "next": "... but you can customize it"
         },     
         {
-            "description": "At least now you get the gist of how this works.",
+            "body": "At least now you get the gist of how this works.",
             "next": "I get it!"
         },  
         {
-            "description": "That's pretty much it.",
+            "body": "That's pretty much it.",
             "next": "Step 5"
-        }            
+        }        
     ]
 }

--- a/js/adapt-stacklist.js
+++ b/js/adapt-stacklist.js
@@ -40,7 +40,7 @@ define(function(require) {
 		setStage: function(stage) {
 			this.model.set("_stage", stage);
 
-			this.$(".stacklist-next").html("Next");
+			this.$(".stacklist-next").html(this.model.get("_items")[stage].next);
 			var $item = this.$(".stacklist-item").eq(stage);
 			$item.show();
 			var h = $item.outerHeight(true);

--- a/js/adapt-stacklist.js
+++ b/js/adapt-stacklist.js
@@ -40,7 +40,9 @@ define(function(require) {
 		setStage: function(stage) {
 			this.model.set("_stage", stage);
 
-			this.$(".stacklist-next").html(this.model.get("_items")[stage].next);
+			var nextButtonText = this.model.get("_items")[stage].next || "Next";
+			this.$(".stacklist-next").html(nextButtonText);
+			
 			var $item = this.$(".stacklist-item").eq(stage);
 			$item.show();
 			var h = $item.outerHeight(true);

--- a/templates/stacklist.hbs
+++ b/templates/stacklist.hbs
@@ -5,11 +5,7 @@
         <div class="stacklist-items">
             {{#each _items}}
             <div class="stacklist-item">
-                {{#if this.length}}
-                    {{{a11y_text this}}}
-                {{else}}
-                    {{{a11y_text body}}}
-                {{/if}}
+                {{#if description}}{{{a11y_text description}}}{{/if}}
             </div>
             {{/each}}
             <div class="stacklist-button">

--- a/templates/stacklist.hbs
+++ b/templates/stacklist.hbs
@@ -5,7 +5,11 @@
         <div class="stacklist-items">
             {{#each _items}}
             <div class="stacklist-item">
-                {{#if description}}{{{a11y_text description}}}{{/if}}
+                {{#if this.length}}
+                    {{{a11y_text this}}}
+                {{else}}
+                    {{{a11y_text body}}}
+                {{/if}}
             </div>
             {{/each}}
             <div class="stacklist-button">


### PR DESCRIPTION
I've added in ability to customise the next button wording - it's connected to each ``adapt-stacklist`` item.

Reasons for that:

- Word 'next' was hard coded onto the component core - making it troublesome during possible translation.
- It can make this component more engaging by further customisation.

Any questions suggestions - please let me know! 

Thanks,
Adam