### PR TITLE
Updates aria-region source to stacklist global

### DIFF
--- a/templates/stacklist.hbs
+++ b/templates/stacklist.hbs
@@ -1,4 +1,4 @@
-<div class="stacklist-inner component-inner" role="region" aria-label="{{_globals._components._text.ariaRegion}}">
+<div class="stacklist-inner component-inner" role="region" aria-label="{{_globals._components._stacklist.ariaRegion}}">
     {{> component this}}
 
     <div class="stacklist-widget component-widget">


### PR DESCRIPTION
Daniel, sorry, missed something. This modifies where ariaRegion is drawn from so it comes from the _globals._components._stacklist instead of _globals._components._text. It goes with my changes to properties.schema from the last pull request. 